### PR TITLE
Remove compiler warning when U_CX_PORT_PRINTF is defined as nothing.

### DIFF
--- a/src/u_cx_log.c
+++ b/src/u_cx_log.c
@@ -53,6 +53,7 @@ static bool gUCxLogEnabled = true;
 
 void uCxLogPrintTime(void)
 {
+#if U_CX_PORT_PRINTF
     int32_t timestamp_ms = U_CX_PORT_GET_TIME_MS();
     int32_t ms      = (int32_t) (timestamp_ms % 1000);
     int32_t seconds = (int32_t) (timestamp_ms / 1000) % 60 ;
@@ -60,6 +61,7 @@ void uCxLogPrintTime(void)
     int32_t hours   = (int32_t) ((timestamp_ms / (1000 * 60 * 60)));
     U_CX_PORT_PRINTF("[%02" PRId32 ":%02" PRId32 ":%02" PRId32 ".%03" PRId32"]",
                      hours, minutes, seconds, ms);
+#endif
 }
 
 void uCxLogDisable(void)


### PR DESCRIPTION
Hi Andreas: just a little tidy up.  There may be other ways of doing this, feel free to suggest.

When using `uxclient` with `ubxlib` we define `U_CX_AT_CONFIG_FILE` in order to use our own configuration file.  When `ubxlib` is configured to have no logging at compile-time, so `U_CX_PORT_PRINTF` is defined to be empty, we get a compiler warning from `uCxLogPrintTime()` because the stack variables in that function are no longer used.  This PR makes the whole of the body of `uCxLogPrintTime()` conditional on `U_CX_PORT_PRINTF` being defined as something useful in order to remove the warning.