### PR TITLE
Add an "instance" number to log output

### DIFF
--- a/examples/http_example.c
+++ b/examples/http_example.c
@@ -96,7 +96,7 @@ static void signalEvent(uint32_t evtFlag)
 static void networkUpUrc(struct uCxHandle *puCxHandle)
 {
     (void)puCxHandle;
-    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "networkUpUrc");
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_DBG, puCxHandle->pAtClient->instance, "networkUpUrc");
     signalEvent(URC_FLAG_NETWORK_UP);
 }
 
@@ -104,7 +104,7 @@ static void sockConnected(struct uCxHandle *puCxHandle, int32_t socket_handle)
 {
     (void)puCxHandle;
     (void)socket_handle;
-    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "sockConnected");
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_DBG, puCxHandle->pAtClient->instance, "sockConnected");
     signalEvent(URC_FLAG_SOCK_CONNECTED);
 }
 
@@ -188,7 +188,7 @@ int main(int argc, char **argv)
     uCxSocketConnect(&ucxHandle, sockHandle, EXAMPLE_URL, 80);
     waitEvent(URC_FLAG_SOCK_CONNECTED, 5);
     ret = uCxSocketWrite(&ucxHandle, sockHandle, (uint8_t *)"GET /\r\n", 7);
-    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "uCxSocketWrite() returned %d", ret);
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_DBG, client.instance, "uCxSocketWrite() returned %d", ret);
     waitEvent(URC_FLAG_SOCK_DATA, 5);
 
     uint8_t rxData[512];

--- a/examples/http_example_no_os.c
+++ b/examples/http_example_no_os.c
@@ -73,7 +73,7 @@ static bool waitEvent(uCxAtClient_t *pClient, uint32_t evtFlag, uint32_t timeout
     int32_t timeoutMs = timeoutS * 1000;
     int32_t startTime = U_CX_PORT_GET_TIME_MS();
 
-    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "waitEvent(%d, %d)", evtFlag, timeoutS);
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_DBG, pClient->instance, "waitEvent(%d, %d)", evtFlag, timeoutS);
     do {
         uCxAtClientHandleRx(pClient);
         if (gUrcEventFlags & evtFlag) {
@@ -81,7 +81,7 @@ static bool waitEvent(uCxAtClient_t *pClient, uint32_t evtFlag, uint32_t timeout
         }
     } while (U_CX_PORT_GET_TIME_MS() - startTime < timeoutMs);
 
-    U_CX_LOG_LINE(U_CX_LOG_CH_WARN, "Timeout waiting for: %d", evtFlag);
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_WARN, pClient->instance, "Timeout waiting for: %d", evtFlag);
     return false;
 }
 
@@ -93,7 +93,7 @@ static void signalEvent(uint32_t evtFlag)
 static void networkUpUrc(struct uCxHandle *puCxHandle)
 {
     (void)puCxHandle;
-    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "networkUpUrc");
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_DBG, puCxHandle->pAtClient->instance, "networkUpUrc");
     signalEvent(URC_FLAG_NETWORK_UP);
 }
 
@@ -101,7 +101,7 @@ static void sockConnected(struct uCxHandle *puCxHandle, int32_t socket_handle)
 {
     (void)puCxHandle;
     (void)socket_handle;
-    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "sockConnected");
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_DBG, puCxHandle->pAtClient->instance, "sockConnected");
     signalEvent(URC_FLAG_SOCK_CONNECTED);
 }
 
@@ -165,7 +165,7 @@ int main(void)
     uCxSocketConnect(&ucxHandle, sockHandle, EXAMPLE_URL, 80);
     waitEvent(&client, URC_FLAG_SOCK_CONNECTED, 5);
     ret = uCxSocketWrite(&ucxHandle, sockHandle, (uint8_t *)"GET /\r\n", 7);
-    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "uCxSocketWrite() returned %d", ret);
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_DBG, client.instance, "uCxSocketWrite() returned %d", ret);
     waitEvent(&client, URC_FLAG_SOCK_DATA, 5);
 
     uint8_t rxData[512];

--- a/examples/port/u_port_no_os.c
+++ b/examples/port/u_port_no_os.c
@@ -198,12 +198,12 @@ bool uPortAtOpen(uCxAtClient_t *pClient, const char *pDevName, int baudRate, boo
     assert(pCtx != NULL);
     assert(pCtx->uartFd == -1);
 
-    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "Opening %s at %d with %s flow control",
-                  pDevName, baudRate, useFlowControl ? "CTS/RTS" : "no");
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_DBG, pClient->instance, "Opening %s at %d with %s flow control",
+                    pDevName, baudRate, useFlowControl ? "CTS/RTS" : "no");
 
     gUartFd = openUart(pDevName, baudRate, useFlowControl);
     if (gUartFd < 0) {
-        U_CX_LOG_LINE(U_CX_LOG_CH_ERROR, "Failed to open UART");
+        U_CX_LOG_LINE_I(U_CX_LOG_CH_ERROR, pClient->instance, "Failed to open UART");
         return false;
     }
     pCtx->uartFd = gUartFd;
@@ -216,7 +216,7 @@ void uPortAtClose(uCxAtClient_t *pClient)
     uPortContext_t *pCtx = pClient->pConfig->pStreamHandle;
     assert(pCtx->uartFd != -1);
 
-    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "Closing UART");
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_DBG, pClient->instance, "Closing UART");
 
     close(pCtx->uartFd);
     pCtx->uartFd = -1;

--- a/examples/port/u_port_posix.c
+++ b/examples/port/u_port_posix.c
@@ -143,7 +143,7 @@ static void *rxTask(void *pArg)
             uCxAtClientHandleRx(pCtx->pClient);
         }
     }
-    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "RX task terminated");
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_DBG, pCtx->pClient->instance, "RX task terminated");
     return NULL;
 }
 
@@ -236,12 +236,12 @@ bool uPortAtOpen(uCxAtClient_t *pClient, const char *pDevName, int baudRate, boo
     assert(pCtx != NULL);
     assert(pCtx->uartFd == -1);
 
-    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "Opening %s at %d with %s flow control",
-                  pDevName, baudRate, useFlowControl ? "CTS/RTS" : "no");
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_DBG, pClient->instance, "Opening %s at %d with %s flow control",
+                    pDevName, baudRate, useFlowControl ? "CTS/RTS" : "no");
 
     gUartFd = openUart(pDevName, baudRate, useFlowControl);
     if (gUartFd < 0) {
-        U_CX_LOG_LINE(U_CX_LOG_CH_ERROR, "Failed to open UART");
+        U_CX_LOG_LINE_I(U_CX_LOG_CH_ERROR, pClient->instance, "Failed to open UART");
         return false;
     }
     pCtx->uartFd = gUartFd;
@@ -264,7 +264,7 @@ void uPortAtClose(uCxAtClient_t *pClient)
     assert(pCtx->uartFd != -1);
     assert(!pCtx->terminateRxTask);
 
-    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "Closing UART");
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_DBG, pClient->instance, "Closing UART");
 
     // Terminate the RX task
     pCtx->terminateRxTask = true;

--- a/examples/port/u_port_zephyr.c
+++ b/examples/port/u_port_zephyr.c
@@ -191,24 +191,24 @@ bool uPortAtOpen(uCxAtClient_t *pClient, const char *pDevName, int baudRate, boo
     U_CX_AT_PORT_ASSERT(pCtx != NULL);
     U_CX_AT_PORT_ASSERT(pCtx->pUartDev == NULL);
 
-    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "Opening %s at %d with %s flow control",
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_DBG, pClient->instance, "Opening %s at %d with %s flow control",
                   pDevName, baudRate, useFlowControl ? "CTS/RTS" : "no");
 
     pCtx->pUartDev = device_get_binding(pDevName);
     if (pCtx->pUartDev == NULL) {
-        U_CX_LOG_LINE(U_CX_LOG_CH_ERROR, "Failed to open UART %s", pDevName);
+        U_CX_LOG_LINE_I(U_CX_LOG_CH_ERROR, pClient->instance, "Failed to open UART %s", pDevName);
         return false;
     }
     if (!device_is_ready(pCtx->pUartDev)) {
-        U_CX_LOG_LINE(U_CX_LOG_CH_ERROR, "UART %s is not ready", pDevName);
+        U_CX_LOG_LINE_I(U_CX_LOG_CH_ERROR, pClient->instance, "UART %s is not ready", pDevName);
         return false;
     }
     if (uart_irq_callback_user_data_set(pCtx->pUartDev, uartIsr, pCtx) < 0) {
-        U_CX_LOG_LINE(U_CX_LOG_CH_ERROR, "Failed to set UART callback");
+        U_CX_LOG_LINE_I(U_CX_LOG_CH_ERROR, pClient->instance, "Failed to set UART callback");
         return false;
     }
     if (uart_configure(pCtx->pUartDev, &config) < 0) {
-        U_CX_LOG_LINE(U_CX_LOG_CH_ERROR, "Failed to configure UART");
+        U_CX_LOG_LINE_I(U_CX_LOG_CH_ERROR, pClient->instance, "Failed to configure UART");
         return false;
     }
 
@@ -223,7 +223,7 @@ void uPortAtClose(uCxAtClient_t *pClient)
     uPortContext_t *pCtx = pClient->pConfig->pStreamHandle;
     U_CX_AT_PORT_ASSERT(pCtx->pUartDev != NULL);
 
-    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "Closing UART");
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_DBG, pClient->instance, "Closing UART");
 
     uart_irq_rx_disable(pCtx->pUartDev);
     k_work_cancel(&pCtx->rxWork);

--- a/inc/u_cx_at_client.h
+++ b/inc/u_cx_at_client.h
@@ -86,6 +86,7 @@ typedef struct uCxAtClient {
     uCxAtBinaryRx_t binaryRx;
     uCxAtBinaryResponseBuf_t rspBinaryBuf;
     U_CX_MUTEX_HANDLE cmdMutex;
+    int32_t instance;
 } uCxAtClient_t;
 
 typedef struct uCxAtClientConfig {

--- a/inc/u_cx_log.h
+++ b/inc/u_cx_log.h
@@ -39,10 +39,14 @@
 #define U_CX_LOG_CH_ERROR  U_CX_LOG_ERROR,     ANSI_RED "[ERROR]"
 
 /* Simple line logging printf style (\n will be added automatically) */
-#define U_CX_LOG_LINE(logCh, format, ...)  _U_CX_LOG_BEGIN_FMT(logCh, format ANSI_RST "\n", ##__VA_ARGS__)
+#define U_CX_LOG_LINE(logCh, format, ...) \
+    _U_CX_LOG_BEGIN_FMT(logCh, format ANSI_RST "\n", ##__VA_ARGS__)
+#define U_CX_LOG_LINE_I(logCh, instance, format, ...) \
+    __U_CX_LOG_BEGIN_I_FMT(logCh, instance, format ANSI_RST "\n", ##__VA_ARGS__)
 
 /* Log API for splitting up line in several U_CX_LOG() calls */
 #define U_CX_LOG_BEGIN(logCh)              _U_CX_LOG_BEGIN_FMT(logCh, "")
+#define U_CX_LOG_BEGIN_I(logCh, instance)  _U_CX_LOG_BEGIN_I_FMT(logCh, instance, "")
 #define U_CX_LOG(logCh, format, ...)       _U_CX_LOG(logCh, format, ##__VA_ARGS__)
 #define U_CX_LOG_END(logCh)                _U_CX_LOG(logCh, ANSI_RST "\n")
 
@@ -71,6 +75,11 @@
         uCxLogPrintTime();                                  \
         U_CX_PORT_PRINTF(chText " " format, ##__VA_ARGS__); \
     }
+#define __U_CX_LOG_BEGIN_I_FMT(enabled, chText, instance, format, ...)  \
+    if (enabled && uCxLogIsEnabled()) {                     \
+        uCxLogPrintTime();                                  \
+        U_CX_PORT_PRINTF(chText "[%d] " format, instance, ##__VA_ARGS__); \
+    }
 #define __U_CX_LOG(enabled, chText, format, ...) \
     if (enabled && uCxLogIsEnabled()) {          \
         U_CX_PORT_PRINTF(format, ##__VA_ARGS__); \
@@ -78,6 +87,7 @@
 /* MSVC workaround */
 #define EXPAND(x) x
 #define _U_CX_LOG_BEGIN_FMT(...) EXPAND(__U_CX_LOG_BEGIN_FMT(__VA_ARGS__))
+#define _U_CX_LOG_BEGIN_I_FMT(...) EXPAND(__U_CX_LOG_BEGIN_I_FMT(__VA_ARGS__))
 #define _U_CX_LOG(...) EXPAND(__U_CX_LOG(__VA_ARGS__))
 
 /* ----------------------------------------------------------------

--- a/ucx_api/u_cx.c
+++ b/ucx_api/u_cx.c
@@ -54,7 +54,8 @@ static void urcCallback(struct uCxAtClient *pClient, void *pTag, char *pLine, si
         paramLen--;
     }
 
-    U_CX_LOG_LINE(U_CX_LOG_CH_DBG, "Received URC '%s', params: '%s'", pLine, pParams);
+    U_CX_LOG_LINE_I(U_CX_LOG_CH_DBG, pClient->instance,
+                    "Received URC '%s', params: '%s'", pLine, pParams);
     uCxUrcParse(puCxHandle, pLine, pParams, paramLen);
 }
 


### PR DESCRIPTION
This is useful when you open multiple instances of the AT client.