### PR TITLE
Reorder includes in u_cx.h

### DIFF
--- a/ucx_api/u_cx.h
+++ b/ucx_api/u_cx.h
@@ -8,12 +8,12 @@
 #include <stdarg.h>
 #include <stdint.h>
 
-#include "u_cx_at_client.h"
-#include "u_cx_types.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include "u_cx_at_client.h"
+#include "u_cx_types.h"
 
 /* ----------------------------------------------------------------
  * COMPILE-TIME MACROS


### PR DESCRIPTION
Moved extern "C" caused to be built as C++ if in a C++ environment.