### PR TITLE
zephyr.yaml: Use python v3.13

### DIFF
--- a/.github/workflows/zephyr.yaml
+++ b/.github/workflows/zephyr.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.13
 
     - name: Copy west.yml
       shell: bash


### PR DESCRIPTION
This fixes the failing Zephyr twister test